### PR TITLE
Fix: handle URL parsing errors & avoid premature termination in multi-target processing

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -66,7 +66,8 @@ func main() {
 
 		tgtPayload, err := payload.GetPayload(target, payload.TestPayload)
 		if err != nil {
-			tgtLogger.WithError(err).Fatal("error getting payload")
+			tgtLogger.WithError(err).Error("error getting payload")
+			continue
 		}
 
 		tgtLogger.Debugln(tgtPayload.URL.String())
@@ -75,7 +76,8 @@ func main() {
 		tgtLogger.Debug("sending payload")
 		resp, err := insecureHttpClient.Do(tgtPayload)
 		if err != nil {
-			tgtLogger.WithError(err).Fatal("error sending payload")
+			tgtLogger.WithError(err).Error("error sending payload")
+			continue
 		}
 
 		if resp.StatusCode > 399 {

--- a/pkg/payload/payload.go
+++ b/pkg/payload/payload.go
@@ -13,32 +13,37 @@ import (
 )
 
 func isValidTarget(target string) error {
-	// Check if it's a valid IP
-	if ip := net.ParseIP(target); ip != nil {
-		return nil
-	}
-
-	if _, err := net.LookupIP(target); err != nil {
-		return fmt.Errorf("could not resolve host: %v", err)
-	}
-
-	// Normalize missing scheme (optional)
+	// Handle missing protocol (without modifying original input)
+	parsingTarget := target
 	if !strings.HasPrefix(target, "http://") && !strings.HasPrefix(target, "https://") {
-		target = "http://" + target
+		parsingTarget = "http://" + target
 	}
 
-	// Check if it's a valid URL
-	parsed, err := url.Parse(target)
+	// Parse URL structure
+	parsed, err := url.Parse(parsingTarget)
 	if err != nil {
 		return fmt.Errorf("could not parse URL: %v", err)
 	}
 
+	// Validate scheme
 	if parsed.Scheme != "http" && parsed.Scheme != "https" {
 		return errors.New("invalid scheme provided")
 	}
 
-	if parsed.Host == "" {
+	// Get real hostname (automatically handles IPv6 brackets and ports)
+	host := parsed.Hostname()
+	if host == "" {
 		return errors.New("invalid host provided")
+	}
+
+	// Check if valid IP format
+	if ip := net.ParseIP(host); ip != nil {
+		return nil
+	}
+
+	// Attempt DNS resolution
+	if _, err := net.LookupIP(host); err != nil {
+		return fmt.Errorf("could not resolve host: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
1. Fix errors that occur when parsing targets like http://ip:port and https://ip:port.
2. Avoid premature termination during multi-target processing.